### PR TITLE
fix: path match should support string type

### DIFF
--- a/cloudflare.js
+++ b/cloudflare.js
@@ -50,7 +50,13 @@ const handleRequest = async (event) => {
 
     // 循环判断该执行那个
     for (let i = 0; i < proxyMyJS.length; i++) {
-        if (proxyMyJS[i].urlReplace[0].test(pathname)) {
+        const pathRegex = proxyMyJS[i].urlReplace[0]
+        const match =
+        typeof pathRegex === 'string'
+          ? pathRegex === pathname
+          : pathRegex.test(pathname)
+
+        if (match) {
             if (method === "OPTIONS") {
                 return handleResponse(new Response(null, {}), null, proxyMyJS[i])
             }


### PR DESCRIPTION
proxyMyJS 里 urlReplace 文档写着支持字符串或者正则表达式。但是实际上字符串类型会出错